### PR TITLE
Setup dev environment: Add AGENTS.md and Linux compatibility fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project structure
+All application code lives under `/workspace/public/`. The root `package.json`, `main.js`, and `index.html` are there — not at the repository root.
+
+### Running the app
+- **Install deps:** `cd /workspace/public && npm install`
+- **Start (dev):** `cd /workspace/public && DISPLAY=:1 npm start` (runs `electron .`)
+- The app opens a GUI window via Xvfb on `:1`. Use `computerUse` subagent or VNC to interact with it.
+
+### Linux platform caveats
+- `systemPreferences.getAccentColor()` in `main.js` is Windows/macOS-only. On Linux it throws. The committed fix wraps it in a try/catch. If the fix is not merged, the app will crash on startup — wrap the call in `try {} catch (_) {}` before running.
+- The `systemPreferences.on('accent-color-changed', ...)` listener has the same issue and also needs a try/catch guard on Linux.
+- D-Bus errors (`Failed to connect to the bus`) in the console are harmless on headless Linux; ignore them.
+- GPU process errors (`Exiting GPU process due to errors during initialization`) are expected on headless Linux with no GPU; the app falls back to software rendering.
+
+### No lint / no tests
+- This project has **no ESLint config** and **no test suite** (`npm test` just echoes an error).
+- There is no lint command to run.
+- Only `npm start` (dev) and `npm run dist` / `npm run pack` (build) are defined.
+
+### Build (packaging)
+- `npm run pack` — builds unpacked distributable
+- `npm run dist` — builds full distributable (configured for Windows NSIS only)
+- Both use `electron-builder` and are optional for development.
+
+### External dependencies
+- **Chrome/Chromium:** `puppeteer-core` does not bundle Chromium. Google Chrome must be installed on the system.
+- **keytar:** Requires `libsecret-1-dev` and `gnome-keyring` on Linux for OS keychain integration.
+- **Xvfb:** Required for headless Electron rendering (already running on `:1` in cloud VMs).

--- a/public/main.js
+++ b/public/main.js
@@ -43,7 +43,8 @@ const createWindow = () => {
   // INFO: Load the index.html of the app -!- //
   mainWindow.loadFile(path.join(__dirname, 'index.html'));
   
-  let color = systemPreferences.getAccentColor()
+  let color = ''
+  try { color = systemPreferences.getAccentColor() } catch (_) {}
   
   autoUpdater.logger = log;
   autoUpdater.logger.transports.file.level = 'info';
@@ -74,9 +75,11 @@ const createWindow = () => {
     mainWindow.webContents.send('blurPw')
   })
 
-  systemPreferences.on('accent-color-changed', (event, newColor) => {
-    mainWindow.webContents.send('accColorChanged', newColor)
-  })
+  try {
+    systemPreferences.on('accent-color-changed', (event, newColor) => {
+      mainWindow.webContents.send('accColorChanged', newColor)
+    })
+  } catch (_) {}
 
   nativeTheme.on('updated', () => {
     if (nativeTheme.shouldUseDarkColors) {

--- a/public/package-lock.json
+++ b/public/package-lock.json
@@ -658,7 +658,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -823,6 +822,7 @@
       "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz",
       "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "archiver-utils": "^2.1.0",
         "async": "^3.2.4",
@@ -841,6 +841,7 @@
       "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
       "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.4",
         "graceful-fs": "^4.2.0",
@@ -862,6 +863,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -876,13 +878,15 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/archiver-utils/node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -1557,6 +1561,7 @@
       "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.2.tgz",
       "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "buffer-crc32": "^0.2.13",
         "crc32-stream": "^4.0.2",
@@ -1660,6 +1665,7 @@
       "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
       "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "crc32": "bin/crc32.njs"
       },
@@ -1672,6 +1678,7 @@
       "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.3.tgz",
       "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "crc-32": "^1.2.0",
         "readable-stream": "^3.4.0"
@@ -1849,8 +1856,7 @@
       "version": "0.0.1581282",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
       "integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/dir-compare": {
       "version": "3.3.0",
@@ -1867,7 +1873,6 @@
       "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-24.13.3.tgz",
       "integrity": "sha512-rcJUkMfnJpfCboZoOOPf4L29TRtEieHNOeAbYPWPxlaBw/Z1RKrRA86dOI9rwaI4tQSc/RD82zTNHprfUHXsoQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "24.13.3",
         "builder-util": "24.13.1",
@@ -2055,6 +2060,7 @@
       "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-24.13.3.tgz",
       "integrity": "sha512-oHkV0iogWfyK+ah9ZIvMDpei1m9ZRpdXcvde1wTpra2U8AFDNNpqJdnin5z+PM1GbQ5BoaKCWas2HSjtR0HwMg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "24.13.3",
         "archiver": "^5.3.1",
@@ -2067,6 +2073,7 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -2081,6 +2088,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -2093,6 +2101,7 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -3271,7 +3280,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/isbinaryfile": {
       "version": "5.0.2",
@@ -3503,6 +3513,7 @@
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
       "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "readable-stream": "^2.0.5"
       },
@@ -3515,6 +3526,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -3529,13 +3541,15 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/lazystream/node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -3551,13 +3565,15 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/lodash.difference": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
       "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/lodash.escaperegexp": {
       "version": "4.1.2",
@@ -3568,7 +3584,8 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
@@ -3579,13 +3596,15 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/lodash.union": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
       "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
@@ -3860,6 +3879,7 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4031,7 +4051,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -4102,7 +4123,6 @@
       "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.39.0.tgz",
       "integrity": "sha512-SzIxz76Kgu17HUIi57HOejPiN0JKa9VCd2GcPY1sAh6RA4BzGZarFQdOYIYrBdUVbtyH7CrDb9uhGEwVXK/YNA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@puppeteer/browsers": "2.13.0",
         "chromium-bidi": "14.0.0",
@@ -4121,7 +4141,6 @@
       "resolved": "https://registry.npmjs.org/puppeteer-extra/-/puppeteer-extra-3.3.6.tgz",
       "integrity": "sha512-rsLBE/6mMxAjlLd06LuGacrukP2bqbzKCLzV1vrhHFavqQE/taQ2UXv3H5P0Ls7nsrASa+6x3bDbXHpqMwq+7A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/debug": "^4.1.0",
         "debug": "^4.1.1",
@@ -4343,6 +4362,7 @@
       "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
       "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "minimatch": "^5.1.0"
       }
@@ -4353,6 +4373,7 @@
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -4363,6 +4384,7 @@
       "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -5329,6 +5351,7 @@
       "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz",
       "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "archiver-utils": "^3.0.4",
         "compress-commons": "^4.1.2",
@@ -5343,6 +5366,7 @@
       "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-3.0.4.tgz",
       "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "glob": "^7.2.3",
         "graceful-fs": "^4.2.0",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for cloud-based development on Linux.

### Changes

- **`AGENTS.md`** — New file with Cursor Cloud specific development instructions including project structure, how to run the app, Linux platform caveats, and external dependency requirements.
- **`public/main.js`** — Minimal platform compatibility fix: wraps `systemPreferences.getAccentColor()` and `systemPreferences.on('accent-color-changed')` in try/catch blocks since these are Windows/macOS-only Electron APIs that throw on Linux.

### Why

The app is designed for Windows but needs to run in a Linux (headless) cloud development environment. Without the try/catch guards, the Electron app crashes immediately on startup with `TypeError: systemPreferences.getAccentColor is not a function`.

### Demo

[iac2_demo_interaction.mp4](https://cursor.com/agents/bc-9be5e6c2-a063-4aef-924d-7e4f39a69b95/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fiac2_demo_interaction.mp4)

IAC 2.0 running in the Linux cloud VM — filling in the URL, username, password fields and expanding Additional Options.

[IAC 2.0 main window running on Linux](https://cursor.com/agents/bc-9be5e6c2-a063-4aef-924d-7e4f39a69b95/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fiac2_app_running.webp)
[IAC 2.0 with URL entered](https://cursor.com/agents/bc-9be5e6c2-a063-4aef-924d-7e4f39a69b95/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fiac2_url_entered.webp)

### Update Script

```
cd /workspace/public && npm install
```


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9be5e6c2-a063-4aef-924d-7e4f39a69b95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9be5e6c2-a063-4aef-924d-7e4f39a69b95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

